### PR TITLE
Add AppVeyor and Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: csharp
+solution: "Google Drive Uploader1.sln"
+
+os:
+- linux
+- osx

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Google Drive Upload Tool
+# Google Drive Upload Tool [![Travis Build Status](https://travis-ci.org/moisesmcardona/GoogleDriveUploadTool.svg?branch=master)](https://travis-ci.org/moisesmcardona/GoogleDriveUploadTool) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/moisesmcardona/GoogleDriveUploadTool?branch=master&svg=true)](https://ci.appveyor.com/project/moisesmcardona/GoogleDriveUploadTool)
 A tool for Windows to upload files to Google Drive. It resumes uploads in case of an error or failure. Perfect for uploading large files or if your connection is unstable. Additionally, files uploaded with this tool will preserve their Modified Date. Also, the software lets you browse and download your Drive contents.
 
 # How to use?

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2017
+image: Visual Studio 2015
 configuration: Release
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,9 @@
-image: Visual Studio 2015
+image: Visual Studio 2017
 configuration: Release
+
+install:
+ - appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+ - nuget Google.Apis.Drive.v3
 
 artifacts:
  - path: '*\bin\Release\*.exe'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,5 @@
+image: Visual Studio 2017
+configuration: Release
+
+artifacts:
+ - path: *\bin\Release\*.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@ image: Visual Studio 2017
 configuration: Release
 
 install:
- - appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
- - nuget Google.Apis.Drive.v3
+ #- appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+ - nuget install Google.Apis.Drive.v3
 
 artifacts:
  - path: '*\bin\Release\*.exe'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,9 @@ image: Visual Studio 2017
 configuration: Release
 
 install:
- #- appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
  - nuget install Google.Apis.Drive.v3
+ 
+build_script: msbuild "Google Drive Uploader1.sln" /p:TargetFrameworkVersion=v4.7.2
 
 artifacts:
  - path: '*\bin\Release\*.exe'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,4 +2,4 @@ image: Visual Studio 2017
 configuration: Release
 
 artifacts:
- - path: *\bin\Release\*.exe
+ - path: "*\bin\Release\*.exe"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,4 +2,4 @@ image: Visual Studio 2017
 configuration: Release
 
 artifacts:
- - path: "*\bin\Release\*.exe"
+ - path: '*\bin\Release\*.exe'


### PR DESCRIPTION
Basic AppVeyor and Travis implementations. Both turn up errors, mainly to do with missing references. See [Travis](https://travis-ci.com/EwoutH/GoogleDriveUploadTool) and [AppVeyor](https://ci.appveyor.com/project/EwoutH/googledriveuploadtool) runs.